### PR TITLE
Remove `tikv_jemallocator` import

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,6 @@ use std::thread;
 use std::time::Instant;
 use tar::EntryType;
 use target_triple::target;
-use tikv_jemallocator::Jemalloc;
 use tokio::sync::mpsc::{self, UnboundedReceiver};
 use url::Url;
 


### PR DESCRIPTION
Hi! I was curious of this project, but I couldn't build it without removing the `tikv_jemallocator` import.

```
git clone https://github.com/dtolnay/fast-rustup
cd fast-rustup
cargo build --release
```
```
   Compiling fast-rustup v0.0.0 (/Users/chrispryer/github/fast-rustup)
error[E0432]: unresolved import `tikv_jemallocator`
  --> src/main.rs:16:5
   |
16 | use tikv_jemallocator::Jemalloc;
   |     ^^^^^^^^^^^^^^^^^ use of undeclared crate or module `tikv_jemallocator`

For more information about this error, try `rustc --explain E0432`.
error: could not compile `fast-rustup` (bin "fast-rustup") due to previous error
```
